### PR TITLE
Fix exception handling in save_analysis

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -203,4 +203,4 @@ def save_analysis(analysis_result, filename):
     
     except Exception as e:
         logger.error(f"Fehler beim Speichern des Analyseergebnisses: {str(e)}")
-        raise 
+        raise PortfolioAnalysisError(str(e)) from e


### PR DESCRIPTION
## Summary
- fix missing exception argument when saving analysis results

## Testing
- `python -m py_compile analysis.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6841d653fcdc8320a64ca0706de423b4